### PR TITLE
fix: correct TickData and BarData constructor field names in client.py

### DIFF
--- a/src/ibkr_mcp/client.py
+++ b/src/ibkr_mcp/client.py
@@ -817,9 +817,8 @@ class IBKRClient:
 
             return TickData(
                 symbol=contract.symbol,
-                tick_type=1,  # Last price
-                price=price,
-                size=size
+                last=price,
+                volume=size
             )
 
         except DataError:
@@ -898,13 +897,13 @@ class IBKRClient:
             return [
                 BarData(
                     date=bar.date,
-                    open=Decimal(str(bar.open)),
-                    high=Decimal(str(bar.high)),
-                    low=Decimal(str(bar.low)),
-                    close=Decimal(str(bar.close)),
+                    open=float(bar.open),
+                    high=float(bar.high),
+                    low=float(bar.low),
+                    close=float(bar.close),
                     volume=bar.volume,
-                    wap=Decimal(str(bar.wap)) if hasattr(bar, 'wap') and bar.wap else None,
-                    count=bar.barCount if hasattr(bar, 'barCount') else None
+                    average=float(bar.wap) if hasattr(bar, 'wap') and bar.wap else None,
+                    bar_count=bar.barCount if hasattr(bar, 'barCount') else None
                 )
                 for bar in bars
             ]


### PR DESCRIPTION
## Summary
- Fixed `TickData` construction to use `last=price, volume=size` instead of `tick_type`, `price`, `size` which don't exist on the model
- Fixed `BarData` construction to use `average=` instead of `wap=` and `bar_count=` instead of `count=`
- Fixed `BarData` OHLC fields from `Decimal` to `float` to match model type definitions

Closes #3

## Test plan
- [ ] Verify `get_market_data()` returns valid `TickData` without Pydantic ValidationError
- [ ] Verify `get_historical_data()` returns valid `BarData` list without Pydantic ValidationError
- [ ] Confirm field values are correctly mapped (last price, volume, average, bar_count)

🤖 Generated with [Claude Code](https://claude.com/claude-code)