### PR TITLE
test: add unit tests for circuit_breaker, config, and models

### DIFF
--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -1,0 +1,307 @@
+"""Tests for TradingCircuitBreaker."""
+
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+
+from ibkr_mcp.utils.circuit_breaker import TradingCircuitBreaker
+
+
+class TestCircuitBreakerInit:
+    """Test circuit breaker initialization."""
+
+    def test_default_limits(self):
+        cb = TradingCircuitBreaker()
+        assert cb.max_loss_per_minute == 1000
+        assert cb.max_trades_per_minute == 50
+        assert cb.max_daily_loss == 5000
+        assert cb.max_position_size == 10000
+
+    def test_custom_limits(self):
+        cb = TradingCircuitBreaker(
+            max_loss_per_minute=500,
+            max_trades_per_minute=10,
+            max_daily_loss=2000,
+            max_position_size=5000,
+        )
+        assert cb.max_loss_per_minute == 500
+        assert cb.max_trades_per_minute == 10
+        assert cb.max_daily_loss == 2000
+        assert cb.max_position_size == 5000
+
+    def test_initial_state(self):
+        cb = TradingCircuitBreaker()
+        assert cb.is_tripped is False
+        assert cb.trip_reason is None
+        assert cb.trip_count == 0
+        assert cb.daily_pnl == 0.0
+        assert cb.minute_losses == []
+        assert cb.minute_trades == []
+
+
+class TestCheckTrade:
+    """Test check_trade method."""
+
+    def test_trade_allowed(self):
+        cb = TradingCircuitBreaker()
+        allowed, reason = cb.check_trade(5000)
+        assert allowed is True
+        assert reason == "OK"
+
+    def test_trade_blocked_when_tripped(self):
+        cb = TradingCircuitBreaker()
+        cb.trip("manual trip")
+        allowed, reason = cb.check_trade(100)
+        assert allowed is False
+        assert "Circuit breaker tripped" in reason
+
+    def test_position_size_exceeded(self):
+        cb = TradingCircuitBreaker(max_position_size=1000)
+        allowed, reason = cb.check_trade(1500)
+        assert allowed is False
+        assert cb.is_tripped is True
+        assert "Position size" in cb.trip_reason
+
+    def test_negative_trade_value_checks_absolute(self):
+        cb = TradingCircuitBreaker(max_position_size=1000)
+        allowed, reason = cb.check_trade(-1500)
+        assert allowed is False
+        assert cb.is_tripped is True
+
+    def test_position_size_at_limit_allowed(self):
+        cb = TradingCircuitBreaker(max_position_size=1000)
+        allowed, reason = cb.check_trade(1000)
+        assert allowed is True
+        assert reason == "OK"
+
+    def test_trades_per_minute_exceeded(self):
+        cb = TradingCircuitBreaker(max_trades_per_minute=3)
+        cb.check_trade(100)
+        cb.check_trade(100)
+        cb.check_trade(100)
+        allowed, reason = cb.check_trade(100)
+        assert allowed is False
+        assert cb.is_tripped is True
+        assert "Too many trades" in cb.trip_reason
+
+    def test_old_trades_expire_from_window(self):
+        cb = TradingCircuitBreaker(max_trades_per_minute=2)
+        # Add a trade timestamped 61 seconds ago
+        cb.minute_trades.append(datetime.now() - timedelta(seconds=61))
+        # This should be allowed since the old trade is outside the window
+        allowed, reason = cb.check_trade(100)
+        assert allowed is True
+
+    def test_trade_recorded_on_success(self):
+        cb = TradingCircuitBreaker()
+        assert len(cb.minute_trades) == 0
+        cb.check_trade(100)
+        assert len(cb.minute_trades) == 1
+
+
+class TestRecordPnl:
+    """Test record_pnl method."""
+
+    def test_positive_pnl(self):
+        cb = TradingCircuitBreaker()
+        cb.record_pnl(500)
+        assert cb.daily_pnl == 500
+
+    def test_negative_pnl_accumulates(self):
+        cb = TradingCircuitBreaker()
+        cb.record_pnl(-100)
+        cb.record_pnl(-200)
+        assert cb.daily_pnl == -300
+
+    def test_daily_loss_trips_breaker(self):
+        cb = TradingCircuitBreaker(max_daily_loss=500)
+        cb.record_pnl(-600)
+        assert cb.is_tripped is True
+        assert "Daily loss" in cb.trip_reason
+
+    def test_daily_loss_at_limit_no_trip(self):
+        cb = TradingCircuitBreaker(max_daily_loss=500)
+        cb.record_pnl(-500)
+        assert cb.is_tripped is False
+
+    def test_minute_loss_trips_breaker(self):
+        cb = TradingCircuitBreaker(max_loss_per_minute=200, max_daily_loss=99999)
+        # The minute loss check sums entries already in minute_losses before
+        # appending the current one. So the third call sees -150 + -100 = -250
+        # which exceeds the 200 limit.
+        cb.record_pnl(-150)
+        cb.record_pnl(-100)
+        assert cb.is_tripped is False
+        cb.record_pnl(-1)
+        assert cb.is_tripped is True
+        assert "Minute loss" in cb.trip_reason
+
+    def test_pnl_recorded_in_minute_losses(self):
+        cb = TradingCircuitBreaker()
+        cb.record_pnl(-50)
+        assert len(cb.minute_losses) == 1
+        assert cb.minute_losses[0][1] == -50
+
+    def test_daily_reset_on_new_day(self):
+        cb = TradingCircuitBreaker()
+        cb.record_pnl(-100)
+        assert cb.daily_pnl == -100
+
+        # Simulate last_reset being yesterday
+        cb.last_reset = datetime.now() - timedelta(days=1)
+        cb.record_pnl(-50)
+        # daily_pnl should have been reset to 0 then -50 applied
+        assert cb.daily_pnl == -50
+
+    def test_old_minute_losses_pruned(self):
+        cb = TradingCircuitBreaker()
+        # Insert an old loss entry
+        old_time = datetime.now() - timedelta(seconds=61)
+        cb.minute_losses.append((old_time, -500))
+        # Recording new pnl should prune the old entry
+        cb.record_pnl(-10)
+        # Only the new entry should remain
+        assert len(cb.minute_losses) == 1
+
+
+class TestTrip:
+    """Test trip method."""
+
+    def test_trip_sets_state(self):
+        cb = TradingCircuitBreaker()
+        cb.trip("test reason")
+        assert cb.is_tripped is True
+        assert cb.trip_reason == "test reason"
+        assert cb.trip_count == 1
+
+    def test_multiple_trips_increment_count(self):
+        cb = TradingCircuitBreaker()
+        cb.trip("first")
+        cb.trip("second")
+        cb.trip("third")
+        assert cb.trip_count == 3
+        assert cb.trip_reason == "third"
+
+
+class TestReset:
+    """Test reset method."""
+
+    def test_reset_success(self):
+        cb = TradingCircuitBreaker()
+        cb.trip("test")
+        result = cb.reset()
+        assert result is True
+        assert cb.is_tripped is False
+        assert cb.trip_reason is None
+
+    def test_reset_preserves_trip_count(self):
+        cb = TradingCircuitBreaker()
+        cb.trip("test")
+        cb.reset()
+        assert cb.trip_count == 1
+
+    def test_reset_blocked_after_3_trips(self):
+        cb = TradingCircuitBreaker()
+        cb.trip("one")
+        cb.trip("two")
+        cb.trip("three")
+        result = cb.reset()
+        assert result is False
+        assert cb.is_tripped is True
+
+    def test_admin_override_after_3_trips(self):
+        cb = TradingCircuitBreaker()
+        cb.trip("one")
+        cb.trip("two")
+        cb.trip("three")
+        result = cb.reset(admin_override=True)
+        assert result is True
+        assert cb.is_tripped is False
+
+    def test_reset_without_trip(self):
+        cb = TradingCircuitBreaker()
+        result = cb.reset()
+        assert result is True
+
+
+class TestGetStatus:
+    """Test get_status method."""
+
+    def test_status_structure(self):
+        cb = TradingCircuitBreaker()
+        status = cb.get_status()
+        assert "is_tripped" in status
+        assert "trip_reason" in status
+        assert "trip_count" in status
+        assert "daily_pnl" in status
+        assert "trades_last_minute" in status
+        assert "loss_last_minute" in status
+        assert "limits" in status
+        assert "utilization" in status
+        assert "last_reset" in status
+
+    def test_status_initial_values(self):
+        cb = TradingCircuitBreaker()
+        status = cb.get_status()
+        assert status["is_tripped"] is False
+        assert status["trip_reason"] is None
+        assert status["trip_count"] == 0
+        assert status["daily_pnl"] == 0.0
+        assert status["trades_last_minute"] == 0
+        assert status["loss_last_minute"] == 0
+
+    def test_status_limits_reflect_config(self):
+        cb = TradingCircuitBreaker(
+            max_loss_per_minute=100,
+            max_trades_per_minute=5,
+            max_daily_loss=1000,
+            max_position_size=2000,
+        )
+        limits = cb.get_status()["limits"]
+        assert limits["max_loss_per_minute"] == 100
+        assert limits["max_trades_per_minute"] == 5
+        assert limits["max_daily_loss"] == 1000
+        assert limits["max_position_size"] == 2000
+
+    def test_status_utilization_zero_when_positive_pnl(self):
+        cb = TradingCircuitBreaker()
+        cb.record_pnl(100)
+        status = cb.get_status()
+        assert status["utilization"]["daily_loss_pct"] == 0
+
+    def test_status_utilization_reflects_activity(self):
+        cb = TradingCircuitBreaker(max_trades_per_minute=10)
+        cb.check_trade(100)
+        cb.check_trade(100)
+        status = cb.get_status()
+        assert status["utilization"]["trades_pct"] == 20.0
+
+    def test_status_after_trade(self):
+        cb = TradingCircuitBreaker()
+        cb.check_trade(100)
+        status = cb.get_status()
+        assert status["trades_last_minute"] == 1
+
+    def test_status_last_reset_is_iso(self):
+        cb = TradingCircuitBreaker()
+        status = cb.get_status()
+        # Should be parseable as ISO format
+        datetime.fromisoformat(status["last_reset"])
+
+
+class TestRepr:
+    """Test __repr__ method."""
+
+    def test_repr_active(self):
+        cb = TradingCircuitBreaker()
+        r = repr(cb)
+        assert "ACTIVE" in r
+        assert "trip_count=0" in r
+
+    def test_repr_tripped(self):
+        cb = TradingCircuitBreaker()
+        cb.trip("test")
+        r = repr(cb)
+        assert "TRIPPED" in r
+        assert "trip_count=1" in r

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,274 @@
+"""Tests for configuration models and utility functions."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from ibkr_mcp.config import (
+    CONNECTION_PRESETS,
+    IBKRConfig,
+    MCPConfig,
+    RiskConfig,
+    ServerConfig,
+    get_port_from_mode,
+)
+
+
+class TestGetPortFromMode:
+    """Test get_port_from_mode utility function."""
+
+    def test_tws_paper(self):
+        assert get_port_from_mode("tws_paper") == 7497
+
+    def test_tws_live(self):
+        assert get_port_from_mode("tws_live") == 7496
+
+    def test_gateway_paper(self):
+        assert get_port_from_mode("gateway_paper") == 4002
+
+    def test_gateway_live(self):
+        assert get_port_from_mode("gateway_live") == 4001
+
+    def test_case_insensitive(self):
+        assert get_port_from_mode("TWS_PAPER") == 7497
+        assert get_port_from_mode("Tws_Live") == 7496
+
+    def test_invalid_mode_returns_fallback(self):
+        assert get_port_from_mode("invalid") == 7497
+
+    def test_none_returns_fallback(self):
+        assert get_port_from_mode(None) == 7497
+
+    def test_empty_string_returns_fallback(self):
+        assert get_port_from_mode("") == 7497
+
+    def test_custom_fallback(self):
+        assert get_port_from_mode("invalid", fallback_port=9999) == 9999
+
+    def test_none_with_custom_fallback(self):
+        assert get_port_from_mode(None, fallback_port=4444) == 4444
+
+
+class TestConnectionPresets:
+    """Test CONNECTION_PRESETS dictionary."""
+
+    def test_all_presets_have_port(self):
+        for name, preset in CONNECTION_PRESETS.items():
+            assert "port" in preset, f"Preset '{name}' missing 'port'"
+
+    def test_all_presets_have_description(self):
+        for name, preset in CONNECTION_PRESETS.items():
+            assert "description" in preset, f"Preset '{name}' missing 'description'"
+
+    def test_expected_presets_exist(self):
+        expected = {"tws_paper", "tws_live", "gateway_paper", "gateway_live"}
+        assert set(CONNECTION_PRESETS.keys()) == expected
+
+
+class TestIBKRConfig:
+    """Test IBKRConfig model."""
+
+    def test_defaults(self):
+        config = IBKRConfig()
+        assert config.host == "127.0.0.1"
+        assert config.port == 7497
+        assert config.client_id == 1
+        assert config.timeout == 30
+        assert config.readonly is False
+        assert config.mode is None
+        assert config.client_id_auto_retry is True
+        assert config.client_id_max_attempts == 5
+        assert config.requests_per_second == 45.0
+        assert config.data_timeout == 2.0
+        assert config.market_timezone == "America/New_York"
+        assert config.max_reconnect_attempts == 5
+        assert config.reconnect_delay == 2.0
+
+    def test_custom_values(self):
+        config = IBKRConfig(
+            host="192.168.1.1",
+            port=7496,
+            client_id=5,
+            timeout=60,
+            readonly=True,
+        )
+        assert config.host == "192.168.1.1"
+        assert config.port == 7496
+        assert config.client_id == 5
+        assert config.timeout == 60
+        assert config.readonly is True
+
+    def test_from_env_defaults(self):
+        with patch.dict(os.environ, {}, clear=True):
+            config = IBKRConfig.from_env()
+        assert config.host == "127.0.0.1"
+        assert config.port == 7497
+        assert config.client_id == 1
+        assert config.timeout == 30
+        assert config.readonly is False
+
+    def test_from_env_with_values(self):
+        env = {
+            "IBKR_HOST": "10.0.0.1",
+            "IBKR_PORT": "7496",
+            "IBKR_CLIENT_ID": "42",
+            "IBKR_TIMEOUT": "60",
+            "IBKR_READONLY": "true",
+            "IBKR_CLIENT_ID_AUTO_RETRY": "false",
+            "IBKR_CLIENT_ID_MAX_ATTEMPTS": "3",
+            "IBKR_RATE_LIMIT": "30",
+            "IBKR_DATA_TIMEOUT": "5.0",
+            "IBKR_TIMEZONE": "US/Central",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            config = IBKRConfig.from_env()
+        assert config.host == "10.0.0.1"
+        assert config.port == 7496
+        assert config.client_id == 42
+        assert config.timeout == 60
+        assert config.readonly is True
+        assert config.client_id_auto_retry is False
+        assert config.client_id_max_attempts == 3
+        assert config.requests_per_second == 30.0
+        assert config.data_timeout == 5.0
+        assert config.market_timezone == "US/Central"
+
+    def test_from_env_with_mode(self):
+        env = {"IBKR_MODE": "gateway_live"}
+        with patch.dict(os.environ, env, clear=True):
+            config = IBKRConfig.from_env()
+        assert config.mode == "gateway_live"
+        assert config.port == 4001
+
+    def test_from_env_mode_overrides_port(self):
+        env = {"IBKR_MODE": "tws_live", "IBKR_PORT": "9999"}
+        with patch.dict(os.environ, env, clear=True):
+            config = IBKRConfig.from_env()
+        # Mode should take precedence over explicit port
+        assert config.port == 7496
+
+    def test_get_mode_description_with_mode(self):
+        config = IBKRConfig(mode="tws_paper")
+        assert config.get_mode_description() == "TWS Paper Trading"
+
+    def test_get_mode_description_inferred_from_port(self):
+        config = IBKRConfig(port=4002)
+        assert config.get_mode_description() == "IB Gateway Paper Trading"
+
+    def test_get_mode_description_custom_port(self):
+        config = IBKRConfig(port=9999)
+        assert config.get_mode_description() == "Custom (port 9999)"
+
+
+class TestMCPConfig:
+    """Test MCPConfig model."""
+
+    def test_defaults(self):
+        config = MCPConfig()
+        assert config.host == "127.0.0.1"
+        assert config.port == 8080
+        assert config.transport == "stdio"
+
+    def test_custom_values(self):
+        config = MCPConfig(host="0.0.0.0", port=3000, transport="sse")
+        assert config.host == "0.0.0.0"
+        assert config.port == 3000
+        assert config.transport == "sse"
+
+
+class TestRiskConfig:
+    """Test RiskConfig model."""
+
+    def test_defaults(self):
+        config = RiskConfig()
+        assert config.max_loss_per_minute == 1000.0
+        assert config.max_trades_per_minute == 50
+        assert config.max_daily_loss == 5000.0
+        assert config.max_position_size == 10000.0
+        assert config.max_margin_utilization == 50.0
+        assert config.max_concentration == 20.0
+
+    def test_custom_values(self):
+        config = RiskConfig(
+            max_loss_per_minute=500,
+            max_trades_per_minute=10,
+            max_daily_loss=2000,
+            max_position_size=5000,
+            max_margin_utilization=80,
+            max_concentration=30,
+        )
+        assert config.max_loss_per_minute == 500
+        assert config.max_trades_per_minute == 10
+        assert config.max_daily_loss == 2000
+        assert config.max_position_size == 5000
+        assert config.max_margin_utilization == 80
+        assert config.max_concentration == 30
+
+
+class TestServerConfig:
+    """Test ServerConfig model."""
+
+    def test_defaults(self):
+        config = ServerConfig()
+        assert isinstance(config.ibkr, IBKRConfig)
+        assert isinstance(config.mcp, MCPConfig)
+        assert isinstance(config.risk, RiskConfig)
+
+    def test_nested_defaults(self):
+        config = ServerConfig()
+        assert config.ibkr.port == 7497
+        assert config.mcp.transport == "stdio"
+        assert config.risk.max_daily_loss == 5000.0
+
+    def test_custom_nested(self):
+        config = ServerConfig(
+            ibkr=IBKRConfig(port=7496),
+            mcp=MCPConfig(transport="sse"),
+            risk=RiskConfig(max_daily_loss=10000),
+        )
+        assert config.ibkr.port == 7496
+        assert config.mcp.transport == "sse"
+        assert config.risk.max_daily_loss == 10000
+
+    def test_from_env_defaults(self):
+        with patch.dict(os.environ, {}, clear=True):
+            config = ServerConfig.from_env()
+        assert config.ibkr.port == 7497
+        assert config.mcp.transport == "stdio"
+        assert config.risk.max_daily_loss == 5000
+
+    def test_from_env_with_values(self):
+        env = {
+            "IBKR_HOST": "10.0.0.1",
+            "IBKR_PORT": "7496",
+            "MCP_HOST": "0.0.0.0",
+            "MCP_PORT": "3000",
+            "MCP_TRANSPORT": "sse",
+            "RISK_MAX_LOSS_PER_MIN": "500",
+            "RISK_MAX_TRADES_PER_MIN": "20",
+            "RISK_MAX_DAILY_LOSS": "2000",
+            "RISK_MAX_POSITION": "5000",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            config = ServerConfig.from_env()
+        assert config.ibkr.host == "10.0.0.1"
+        assert config.ibkr.port == 7496
+        assert config.mcp.host == "0.0.0.0"
+        assert config.mcp.port == 3000
+        assert config.mcp.transport == "sse"
+        assert config.risk.max_loss_per_minute == 500
+        assert config.risk.max_trades_per_minute == 20
+        assert config.risk.max_daily_loss == 2000
+        assert config.risk.max_position_size == 5000
+
+    def test_conftest_ibkr_config_fixture(self, ibkr_config):
+        """Verify the conftest fixture works correctly."""
+        assert ibkr_config.client_id == 99
+        assert ibkr_config.readonly is True
+        assert ibkr_config.timeout == 10
+
+    def test_conftest_server_config_fixture(self, server_config):
+        """Verify the conftest server_config fixture works correctly."""
+        assert server_config.ibkr.client_id == 99
+        assert server_config.mcp.transport == "stdio"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,688 @@
+"""Tests for Pydantic data models."""
+
+from datetime import datetime
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from ibkr_mcp.models import (
+    AccountSummary,
+    AlgoStrategy,
+    BarData,
+    BracketOrder,
+    Contract,
+    FuturesContract,
+    MCPResponse,
+    OptionChain,
+    OptionContract,
+    OptionRight,
+    OptionSpread,
+    OptionSpreadStrategy,
+    Order,
+    OrderAction,
+    OrderBook,
+    OrderStatus,
+    OrderType,
+    PortfolioAllocation,
+    Position,
+    PositionSizing,
+    RiskLimits,
+    RolloverInfo,
+    ScannerRequest,
+    ScannerResult,
+    SecType,
+    TickData,
+    TimeInForce,
+    TrailingStop,
+    VaRResult,
+)
+
+
+# =============================================================================
+# Enum Tests
+# =============================================================================
+
+
+class TestEnums:
+    """Test enum values match IBKR protocol."""
+
+    def test_order_action_values(self):
+        assert OrderAction.BUY.value == "BUY"
+        assert OrderAction.SELL.value == "SELL"
+
+    def test_order_type_values(self):
+        assert OrderType.MARKET.value == "MKT"
+        assert OrderType.LIMIT.value == "LMT"
+        assert OrderType.STOP.value == "STP"
+        assert OrderType.STOP_LIMIT.value == "STP LMT"
+        assert OrderType.TRAIL.value == "TRAIL"
+        assert OrderType.TRAIL_LIMIT.value == "TRAIL LIMIT"
+
+    def test_order_status_values(self):
+        assert OrderStatus.FILLED.value == "Filled"
+        assert OrderStatus.CANCELLED.value == "Cancelled"
+        assert OrderStatus.SUBMITTED.value == "Submitted"
+        assert OrderStatus.REJECTED.value == "Rejected"
+        assert OrderStatus.INACTIVE.value == "Inactive"
+
+    def test_time_in_force_values(self):
+        assert TimeInForce.DAY.value == "DAY"
+        assert TimeInForce.GTC.value == "GTC"
+        assert TimeInForce.IOC.value == "IOC"
+        assert TimeInForce.GTD.value == "GTD"
+
+    def test_sec_type_values(self):
+        assert SecType.STOCK.value == "STK"
+        assert SecType.OPTION.value == "OPT"
+        assert SecType.FUTURE.value == "FUT"
+        assert SecType.FOREX.value == "CASH"
+        assert SecType.INDEX.value == "IND"
+        assert SecType.CFD.value == "CFD"
+        assert SecType.BOND.value == "BOND"
+        assert SecType.WARRANT.value == "WAR"
+        assert SecType.COMMODITY.value == "CMDTY"
+
+    def test_algo_strategy_values(self):
+        assert AlgoStrategy.VWAP.value == "Vwap"
+        assert AlgoStrategy.TWAP.value == "Twap"
+        assert AlgoStrategy.ADAPTIVE.value == "Adaptive"
+
+    def test_option_right_values(self):
+        assert OptionRight.CALL.value == "C"
+        assert OptionRight.PUT.value == "P"
+
+    def test_option_spread_strategy_values(self):
+        assert OptionSpreadStrategy.BULL_CALL.value == "bull_call"
+        assert OptionSpreadStrategy.IRON_CONDOR.value == "iron_condor"
+        assert OptionSpreadStrategy.STRADDLE.value == "straddle"
+
+
+# =============================================================================
+# Contract Model Tests
+# =============================================================================
+
+
+class TestContract:
+    """Test Contract model."""
+
+    def test_minimal_contract(self):
+        c = Contract(symbol="AAPL", sec_type=SecType.STOCK)
+        assert c.symbol == "AAPL"
+        assert c.sec_type == SecType.STOCK
+        assert c.exchange == "SMART"
+        assert c.currency == "USD"
+
+    def test_option_contract(self):
+        c = Contract(
+            symbol="AAPL",
+            sec_type=SecType.OPTION,
+            strike=Decimal("150.00"),
+            right=OptionRight.CALL,
+            expiry="20260320",
+        )
+        assert c.strike == Decimal("150.00")
+        assert c.right == OptionRight.CALL
+        assert c.expiry == "20260320"
+
+    def test_futures_contract(self):
+        c = Contract(
+            symbol="ES",
+            sec_type=SecType.FUTURE,
+            exchange="CME",
+            last_trade_date="20260320",
+            multiplier=50.0,
+        )
+        assert c.last_trade_date == "20260320"
+        assert c.multiplier == 50.0
+
+    def test_missing_required_symbol_raises(self):
+        with pytest.raises(ValidationError):
+            Contract(sec_type=SecType.STOCK)
+
+    def test_missing_required_sec_type_raises(self):
+        with pytest.raises(ValidationError):
+            Contract(symbol="AAPL")
+
+    def test_optional_fields_default_none(self):
+        c = Contract(symbol="AAPL", sec_type=SecType.STOCK)
+        assert c.local_symbol is None
+        assert c.con_id is None
+        assert c.strike is None
+        assert c.right is None
+
+
+# =============================================================================
+# Order Model Tests
+# =============================================================================
+
+
+class TestOrder:
+    """Test Order model and validators."""
+
+    def test_market_order(self):
+        order = Order(
+            action=OrderAction.BUY,
+            total_quantity=Decimal("100"),
+            order_type=OrderType.MARKET,
+        )
+        assert order.action == OrderAction.BUY
+        assert order.total_quantity == Decimal("100")
+        assert order.order_type == OrderType.MARKET
+        assert order.time_in_force == TimeInForce.DAY
+
+    def test_limit_order(self):
+        order = Order(
+            action=OrderAction.SELL,
+            total_quantity=Decimal("50"),
+            order_type=OrderType.LIMIT,
+            lmt_price=Decimal("150.50"),
+        )
+        assert order.lmt_price == Decimal("150.50")
+
+    def test_validate_quantity_positive(self):
+        order = Order(
+            action=OrderAction.BUY,
+            total_quantity=Decimal("1"),
+            order_type=OrderType.MARKET,
+        )
+        assert order.total_quantity == Decimal("1")
+
+    def test_validate_quantity_zero_raises(self):
+        with pytest.raises(ValidationError, match="Quantity must be positive"):
+            Order(
+                action=OrderAction.BUY,
+                total_quantity=Decimal("0"),
+                order_type=OrderType.MARKET,
+            )
+
+    def test_validate_quantity_negative_raises(self):
+        with pytest.raises(ValidationError, match="Quantity must be positive"):
+            Order(
+                action=OrderAction.BUY,
+                total_quantity=Decimal("-10"),
+                order_type=OrderType.MARKET,
+            )
+
+    def test_fractional_quantity(self):
+        order = Order(
+            action=OrderAction.BUY,
+            total_quantity=Decimal("0.5"),
+            order_type=OrderType.MARKET,
+        )
+        assert order.total_quantity == Decimal("0.5")
+
+    def test_optional_fields_default(self):
+        order = Order(
+            action=OrderAction.BUY,
+            total_quantity=Decimal("10"),
+            order_type=OrderType.MARKET,
+        )
+        assert order.order_id is None
+        assert order.client_id is None
+        assert order.lmt_price is None
+        assert order.outside_rth is False
+        assert order.hidden is False
+        assert order.algo_strategy is None
+
+    def test_algo_order(self):
+        order = Order(
+            action=OrderAction.BUY,
+            total_quantity=Decimal("100"),
+            order_type=OrderType.LIMIT,
+            lmt_price=Decimal("150"),
+            algo_strategy=AlgoStrategy.VWAP,
+            algo_params={"maxPctVol": "0.1"},
+        )
+        assert order.algo_strategy == AlgoStrategy.VWAP
+        assert order.algo_params == {"maxPctVol": "0.1"}
+
+    def test_missing_action_raises(self):
+        with pytest.raises(ValidationError):
+            Order(total_quantity=Decimal("10"), order_type=OrderType.MARKET)
+
+    def test_missing_order_type_raises(self):
+        with pytest.raises(ValidationError):
+            Order(action=OrderAction.BUY, total_quantity=Decimal("10"))
+
+
+class TestBracketOrder:
+    """Test BracketOrder model."""
+
+    def test_basic_bracket(self):
+        bo = BracketOrder(
+            symbol="AAPL",
+            action=OrderAction.BUY,
+            quantity=100,
+            entry_price=150.0,
+            profit_target=160.0,
+            stop_loss=145.0,
+        )
+        assert bo.symbol == "AAPL"
+        assert bo.sec_type == SecType.STOCK
+        assert bo.exchange == "SMART"
+
+    def test_futures_bracket(self):
+        bo = BracketOrder(
+            symbol="ES",
+            action=OrderAction.BUY,
+            quantity=1,
+            entry_price=5000.0,
+            profit_target=5050.0,
+            stop_loss=4950.0,
+            sec_type=SecType.FUTURE,
+            exchange="CME",
+        )
+        assert bo.sec_type == SecType.FUTURE
+        assert bo.exchange == "CME"
+
+
+class TestTrailingStop:
+    """Test TrailingStop model."""
+
+    def test_trail_amount(self):
+        ts = TrailingStop(
+            symbol="AAPL",
+            action=OrderAction.SELL,
+            quantity=100,
+            trail_amount=5.0,
+        )
+        assert ts.trail_amount == 5.0
+        assert ts.trail_percent is None
+
+    def test_trail_percent(self):
+        ts = TrailingStop(
+            symbol="AAPL",
+            action=OrderAction.SELL,
+            quantity=100,
+            trail_percent=2.0,
+        )
+        assert ts.trail_percent == 2.0
+        assert ts.trail_amount is None
+
+
+# =============================================================================
+# Position & Account Model Tests
+# =============================================================================
+
+
+class TestPosition:
+    """Test Position model."""
+
+    def test_position_creation(self):
+        contract = Contract(symbol="AAPL", sec_type=SecType.STOCK)
+        pos = Position(
+            account="DU12345",
+            contract=contract,
+            position=Decimal("100"),
+            avg_cost=Decimal("150.00"),
+        )
+        assert pos.account == "DU12345"
+        assert pos.position == Decimal("100")
+        assert pos.market_price is None
+
+    def test_position_with_pnl(self):
+        contract = Contract(symbol="AAPL", sec_type=SecType.STOCK)
+        pos = Position(
+            account="DU12345",
+            contract=contract,
+            position=Decimal("100"),
+            avg_cost=Decimal("150.00"),
+            market_price=Decimal("155.00"),
+            unrealized_pnl=Decimal("500.00"),
+        )
+        assert pos.unrealized_pnl == Decimal("500.00")
+
+
+class TestAccountSummary:
+    """Test AccountSummary model."""
+
+    def test_creation(self):
+        summary = AccountSummary(
+            account="DU12345",
+            tag="NetLiquidation",
+            value="100000.00",
+            currency="USD",
+        )
+        assert summary.tag == "NetLiquidation"
+        assert summary.value == "100000.00"
+
+
+class TestPortfolioAllocation:
+    """Test PortfolioAllocation model."""
+
+    def test_creation(self):
+        alloc = PortfolioAllocation(
+            total_value=100000.0,
+            by_asset_class={"STK": {"value": 80000, "pct": 80}},
+            by_symbol={"AAPL": {"value": 50000, "pct": 50}},
+            by_currency={"USD": {"value": 100000, "pct": 100}},
+            position_count=5,
+        )
+        assert alloc.total_value == 100000.0
+        assert alloc.position_count == 5
+
+
+# =============================================================================
+# Market Data Model Tests
+# =============================================================================
+
+
+class TestTickData:
+    """Test TickData model."""
+
+    def test_minimal(self):
+        tick = TickData(symbol="AAPL")
+        assert tick.symbol == "AAPL"
+        assert tick.bid is None
+        assert tick.ask is None
+        assert isinstance(tick.timestamp, datetime)
+
+    def test_full_tick(self):
+        tick = TickData(
+            symbol="AAPL",
+            bid=149.90,
+            ask=150.10,
+            last=150.00,
+            volume=1000000,
+            high=151.0,
+            low=148.5,
+        )
+        assert tick.bid == 149.90
+        assert tick.ask == 150.10
+
+
+class TestBarData:
+    """Test BarData model."""
+
+    def test_creation(self):
+        now = datetime.now()
+        bar = BarData(
+            date=now,
+            open=150.0,
+            high=152.0,
+            low=149.0,
+            close=151.5,
+            volume=500000,
+        )
+        assert bar.open == 150.0
+        assert bar.close == 151.5
+        assert bar.average is None
+
+    def test_missing_required_raises(self):
+        with pytest.raises(ValidationError):
+            BarData(date=datetime.now(), open=150.0)
+
+
+class TestOrderBook:
+    """Test OrderBook model."""
+
+    def test_creation(self):
+        now = datetime.now()
+        ob = OrderBook(
+            symbol="AAPL",
+            bids=[{"price": 149.90, "size": 100}],
+            asks=[{"price": 150.10, "size": 200}],
+            spread=0.20,
+            mid_price=150.0,
+            imbalance=-0.33,
+            timestamp=now,
+        )
+        assert ob.spread == 0.20
+        assert len(ob.bids) == 1
+
+
+# =============================================================================
+# Options Model Tests
+# =============================================================================
+
+
+class TestOptionContract:
+    """Test OptionContract model."""
+
+    def test_call_option(self):
+        opt = OptionContract(
+            symbol="AAPL",
+            expiry="20260320",
+            strike=150.0,
+            right=OptionRight.CALL,
+            delta=0.55,
+            theta=-0.05,
+        )
+        assert opt.right == OptionRight.CALL
+        assert opt.delta == 0.55
+
+    def test_put_option(self):
+        opt = OptionContract(
+            symbol="AAPL",
+            expiry="20260320",
+            strike=150.0,
+            right=OptionRight.PUT,
+        )
+        assert opt.right == OptionRight.PUT
+
+
+class TestOptionChain:
+    """Test OptionChain model."""
+
+    def test_creation(self):
+        chain = OptionChain(
+            symbol="AAPL",
+            underlying_price=150.0,
+            expirations=["20260320", "20260417"],
+            options=[],
+        )
+        assert len(chain.expirations) == 2
+        assert chain.options == []
+
+
+class TestOptionSpread:
+    """Test OptionSpread model."""
+
+    def test_bull_call(self):
+        spread = OptionSpread(
+            strategy=OptionSpreadStrategy.BULL_CALL,
+            symbol="AAPL",
+            underlying_price=150.0,
+            legs=[
+                {"strike": 145, "right": "C", "action": "BUY"},
+                {"strike": 155, "right": "C", "action": "SELL"},
+            ],
+            total_cost=3.50,
+            max_profit=6.50,
+            max_loss=3.50,
+            breakeven=[148.50],
+        )
+        assert spread.strategy == OptionSpreadStrategy.BULL_CALL
+        assert len(spread.legs) == 2
+
+
+# =============================================================================
+# Futures Model Tests
+# =============================================================================
+
+
+class TestFuturesContract:
+    """Test FuturesContract model."""
+
+    def test_creation(self):
+        fc = FuturesContract(
+            symbol="ES",
+            local_symbol="ESH6",
+            con_id=12345,
+            last_trade_date="20260320",
+            multiplier=50.0,
+            exchange="CME",
+        )
+        assert fc.symbol == "ES"
+        assert fc.is_front_month is False
+        assert fc.is_continuous is False
+
+    def test_front_month(self):
+        fc = FuturesContract(
+            symbol="ES",
+            local_symbol="ESH6",
+            con_id=12345,
+            last_trade_date="20260320",
+            multiplier=50.0,
+            exchange="CME",
+            is_front_month=True,
+        )
+        assert fc.is_front_month is True
+
+
+class TestRolloverInfo:
+    """Test RolloverInfo model."""
+
+    def test_no_rollover_needed(self):
+        ri = RolloverInfo(rollover_needed=False)
+        assert ri.current_contract is None
+        assert ri.recommendation is None
+
+    def test_rollover_needed(self):
+        fc = FuturesContract(
+            symbol="ES",
+            local_symbol="ESH6",
+            con_id=12345,
+            last_trade_date="20260320",
+            multiplier=50.0,
+            exchange="CME",
+        )
+        ri = RolloverInfo(
+            rollover_needed=True,
+            current_contract=fc,
+            days_to_expiry=5,
+            recommendation="Roll to next month",
+        )
+        assert ri.rollover_needed is True
+        assert ri.days_to_expiry == 5
+
+
+# =============================================================================
+# Scanner Model Tests
+# =============================================================================
+
+
+class TestScannerResult:
+    """Test ScannerResult model."""
+
+    def test_creation(self):
+        sr = ScannerResult(
+            rank=1,
+            symbol="AAPL",
+            sec_type="STK",
+            exchange="SMART",
+            currency="USD",
+            current_price=150.0,
+            volume=1000000,
+        )
+        assert sr.rank == 1
+        assert sr.current_price == 150.0
+
+
+class TestScannerRequest:
+    """Test ScannerRequest model."""
+
+    def test_defaults(self):
+        req = ScannerRequest(scan_code="TOP_PERC_GAIN")
+        assert req.location == "STK.US.MAJOR"
+        assert req.instrument == "STK"
+        assert req.num_rows == 50
+        assert req.filters is None
+
+    def test_custom(self):
+        req = ScannerRequest(
+            scan_code="HOT_BY_VOLUME",
+            location="STK.US",
+            num_rows=10,
+            filters={"priceAbove": 5.0},
+        )
+        assert req.num_rows == 10
+        assert req.filters["priceAbove"] == 5.0
+
+
+# =============================================================================
+# Risk Model Tests
+# =============================================================================
+
+
+class TestPositionSizing:
+    """Test PositionSizing model."""
+
+    def test_creation(self):
+        ps = PositionSizing(
+            symbol="AAPL",
+            method="fixed_risk",
+            position_size=66,
+            entry_price=150.0,
+            stop_loss=145.0,
+            risk_amount=330.0,
+            total_value=9900.0,
+            risk_per_share=5.0,
+            risk_percentage=1.0,
+        )
+        assert ps.position_size == 66
+        assert ps.risk_per_share == 5.0
+
+
+class TestRiskLimits:
+    """Test RiskLimits model."""
+
+    def test_creation(self):
+        rl = RiskLimits(
+            overall_status="OK",
+            net_liquidation=100000.0,
+            margin_utilization={"current": 30.0, "limit": 50.0},
+            concentration_risk={"max": 15.0, "limit": 20.0},
+            buying_power={"available": 200000.0},
+            largest_position={"symbol": "AAPL", "pct": 15.0},
+        )
+        assert rl.overall_status == "OK"
+
+
+class TestVaRResult:
+    """Test VaRResult model."""
+
+    def test_creation(self):
+        var = VaRResult(
+            portfolio_value=100000.0,
+            confidence_level=0.95,
+            time_horizon_days=1,
+            parametric_var={"var": 2500.0, "pct": 2.5},
+            historical_var={"var": 2800.0, "pct": 2.8},
+            interpretation="95% confidence 1-day VaR",
+        )
+        assert var.confidence_level == 0.95
+
+
+# =============================================================================
+# Response Model Tests
+# =============================================================================
+
+
+class TestMCPResponse:
+    """Test MCPResponse model."""
+
+    def test_success_response(self):
+        resp = MCPResponse(
+            success=True,
+            message="Order placed",
+            data={"order_id": 123},
+        )
+        assert resp.success is True
+        assert resp.error is None
+        assert isinstance(resp.timestamp, datetime)
+
+    def test_error_response(self):
+        resp = MCPResponse(
+            success=False,
+            error="Connection failed",
+        )
+        assert resp.success is False
+        assert resp.error == "Connection failed"
+
+    def test_serialization_roundtrip(self):
+        resp = MCPResponse(success=True, message="ok")
+        data = resp.model_dump()
+        assert data["success"] is True
+        assert "timestamp" in data


### PR DESCRIPTION
## Summary

- Adds **122 unit tests** across 3 new test files, bringing test coverage from 0 to comprehensive for the three priority modules
- **`test_circuit_breaker.py`** (36 tests): Covers initialization, `check_trade` position size/velocity limits, `record_pnl` minute/daily loss thresholds with rolling window pruning, trip/reset logic including admin override lockout, status reporting, and repr
- **`test_config.py`** (33 tests): Covers `get_port_from_mode` with all presets and edge cases, `IBKRConfig.from_env()` with full env var mapping and mode overrides, `get_mode_description` inference, all config model defaults, and `ServerConfig.from_env()` integration
- **`test_models.py`** (53 tests): Covers all enum values matching IBKR protocol, Pydantic validation including `Order.validate_quantity` rejecting zero/negative, required field enforcement, optional field defaults, and serialization roundtrip

All tests are pure-logic with no IBKR dependency required. Uses existing `conftest.py` fixtures where applicable.

Closes #4

## Test plan

- [x] All 122 tests pass (`pytest tests/ -v` → 122 passed in 0.08s)
- [x] No external dependencies required (no IBKR connection needed)
- [x] Tests exercise edge cases: rolling window expiry, daily P&L reset on new day, admin override lockout after 3 trips, env var precedence

🤖 Generated with [Claude Code](https://claude.com/claude-code)