### PR TITLE
feat: wire circuit breaker into order execution path

### DIFF
--- a/src/ibkr_mcp/server.py
+++ b/src/ibkr_mcp/server.py
@@ -12,6 +12,8 @@ from loguru import logger
 from .config import ServerConfig
 from .client import IBKRClient
 from .models import SecType, OrderAction, OrderType, AlgoStrategy
+from .utils.circuit_breaker import TradingCircuitBreaker
+from .exceptions import CircuitBreakerError
 
 
 class IBKRMCPServer:
@@ -20,12 +22,67 @@ class IBKRMCPServer:
     def __init__(self, config: ServerConfig):
         self.config = config
         self.client = IBKRClient(config.ibkr)
+        self.circuit_breaker = TradingCircuitBreaker(
+            max_loss_per_minute=config.risk.max_loss_per_minute,
+            max_trades_per_minute=config.risk.max_trades_per_minute,
+            max_daily_loss=config.risk.max_daily_loss,
+            max_position_size=config.risk.max_position_size,
+        )
+        # Wire circuit breaker into fill callbacks for P&L tracking
+        self.client.register_event_handler('order_status', self._on_order_status)
         self.mcp = FastMCP(
             "IBKR MCP Server",
             version="1.0.0",
             description="Full-featured Interactive Brokers integration for AI assistants",
         )
         self._setup_tools()
+
+    def _estimate_trade_value(
+        self,
+        quantity: int,
+        limit_price: Optional[float] = None,
+        stop_price: Optional[float] = None,
+        entry_price: Optional[float] = None,
+    ) -> float:
+        """Estimate dollar value of a trade for circuit breaker checks."""
+        price = limit_price or stop_price or entry_price
+        if price and quantity:
+            return abs(quantity * price)
+        return 0.0
+
+    def _check_circuit_breaker(self, trade_value: float) -> Optional[Dict[str, Any]]:
+        """Check circuit breaker before trade. Returns error dict if blocked, None if OK."""
+        allowed, reason = self.circuit_breaker.check_trade(trade_value)
+        if not allowed:
+            return {
+                "success": False,
+                "error": f"Circuit breaker: {reason}",
+                "timestamp": datetime.now().isoformat(),
+            }
+        return None
+
+    def _on_order_status(self, event_data: Dict[str, Any]) -> None:
+        """Track order fills for circuit breaker P&L monitoring."""
+        try:
+            status = event_data.get('status', '')
+            if status == 'Filled':
+                filled = event_data.get('filled', 0)
+                avg_price = event_data.get('avg_fill_price', 0)
+                action = event_data.get('action', '')
+                commission = event_data.get('commission')
+
+                # Record commission as realized cost
+                if commission:
+                    self.circuit_breaker.record_pnl(-abs(commission))
+                    logger.debug(
+                        f"Circuit breaker recorded commission: -${abs(commission):.2f}"
+                    )
+
+                logger.info(
+                    f"Circuit breaker tracked fill: {action} {filled} @ ${avg_price}"
+                )
+        except Exception as e:
+            logger.error(f"Error in circuit breaker fill handler: {e}")
 
     def _setup_tools(self) -> None:
         """Register all MCP tools."""
@@ -198,6 +255,11 @@ class IBKRMCPServer:
             if self.config.ibkr.readonly:
                 return {"success": False, "error": "Read-only mode - trading disabled"}
 
+            trade_value = self._estimate_trade_value(quantity, limit_price=limit_price, stop_price=stop_price)
+            blocked = self._check_circuit_breaker(trade_value)
+            if blocked:
+                return blocked
+
             try:
                 result = await self.client.place_order(
                     symbol=symbol,
@@ -232,6 +294,11 @@ class IBKRMCPServer:
             """Place a bracket order (entry + take profit + stop loss)."""
             if self.config.ibkr.readonly:
                 return {"success": False, "error": "Read-only mode - trading disabled"}
+
+            trade_value = self._estimate_trade_value(quantity, entry_price=entry_price)
+            blocked = self._check_circuit_breaker(trade_value)
+            if blocked:
+                return blocked
 
             try:
                 result = await self.client.place_bracket_order(
@@ -411,6 +478,10 @@ class IBKRMCPServer:
             if self.config.ibkr.readonly:
                 return {"success": False, "error": "Read-only mode - trading disabled"}
 
+            blocked = self._check_circuit_breaker(0.0)
+            if blocked:
+                return blocked
+
             try:
                 from .tools.orders_advanced import create_twap_params, place_algo_order
 
@@ -457,6 +528,10 @@ class IBKRMCPServer:
             """Place a VWAP (Volume-Weighted Average Price) algorithmic order."""
             if self.config.ibkr.readonly:
                 return {"success": False, "error": "Read-only mode - trading disabled"}
+
+            blocked = self._check_circuit_breaker(0.0)
+            if blocked:
+                return blocked
 
             try:
                 from .tools.orders_advanced import create_vwap_params, place_algo_order
@@ -507,6 +582,10 @@ class IBKRMCPServer:
             if self.config.ibkr.readonly:
                 return {"success": False, "error": "Read-only mode - trading disabled"}
 
+            blocked = self._check_circuit_breaker(0.0)
+            if blocked:
+                return blocked
+
             try:
                 from .tools.orders_advanced import create_arrival_price_params, place_algo_order
 
@@ -552,6 +631,10 @@ class IBKRMCPServer:
             """Place an IB Adaptive algorithmic order."""
             if self.config.ibkr.readonly:
                 return {"success": False, "error": "Read-only mode - trading disabled"}
+
+            blocked = self._check_circuit_breaker(0.0)
+            if blocked:
+                return blocked
 
             try:
                 from .tools.orders_advanced import create_adaptive_params, place_algo_order
@@ -677,6 +760,10 @@ class IBKRMCPServer:
             if self.config.ibkr.readonly:
                 return {"success": False, "error": "Read-only mode - trading disabled"}
 
+            blocked = self._check_circuit_breaker(0.0)
+            if blocked:
+                return blocked
+
             try:
                 result = await self.client.execute_rebalancing(
                     rebalancing_plan=rebalancing_plan,
@@ -763,6 +850,10 @@ class IBKRMCPServer:
             if self.config.ibkr.readonly:
                 return {"success": False, "error": "Read-only mode - trading disabled"}
 
+            blocked = self._check_circuit_breaker(0.0)
+            if blocked:
+                return blocked
+
             try:
                 result = await self.client.place_trailing_stop(
                     symbol=symbol,
@@ -792,6 +883,10 @@ class IBKRMCPServer:
             if self.config.ibkr.readonly:
                 return {"success": False, "error": "Read-only mode - trading disabled"}
 
+            blocked = self._check_circuit_breaker(0.0)
+            if blocked:
+                return blocked
+
             try:
                 result = await self.client.place_one_cancels_all(
                     orders=orders,
@@ -820,6 +915,10 @@ class IBKRMCPServer:
             """Place an algorithmic order using IBKR's algo strategies."""
             if self.config.ibkr.readonly:
                 return {"success": False, "error": "Read-only mode - trading disabled"}
+
+            blocked = self._check_circuit_breaker(0.0)
+            if blocked:
+                return blocked
 
             try:
                 result = await self.client.place_algo_order(
@@ -911,6 +1010,10 @@ class IBKRMCPServer:
             if self.config.ibkr.readonly:
                 return {"success": False, "error": "Read-only mode - trading disabled"}
 
+            blocked = self._check_circuit_breaker(0.0)
+            if blocked:
+                return blocked
+
             try:
                 result = await self.client.set_stop_loss_orders(
                     trail_percent=trail_percent,
@@ -923,6 +1026,47 @@ class IBKRMCPServer:
                 }
             except Exception as e:
                 logger.error(f"Stop loss order error: {e}")
+                return {"success": False, "error": str(e), "timestamp": datetime.now().isoformat()}
+
+        # =====================================================================
+        # Circuit Breaker Tools
+        # =====================================================================
+
+        @self.mcp.tool()
+        async def circuit_breaker_status() -> Dict[str, Any]:
+            """Get circuit breaker status including trip state, daily P&L, and utilization."""
+            try:
+                status = self.circuit_breaker.get_status()
+                return {
+                    "success": True,
+                    "data": status,
+                    "timestamp": datetime.now().isoformat(),
+                }
+            except Exception as e:
+                logger.error(f"Circuit breaker status error: {e}")
+                return {"success": False, "error": str(e), "timestamp": datetime.now().isoformat()}
+
+        @self.mcp.tool()
+        async def circuit_breaker_reset(admin_override: bool = False) -> Dict[str, Any]:
+            """Reset the circuit breaker after it has been tripped.
+
+            Args:
+                admin_override: Force reset even if trip count >= 3.
+            """
+            try:
+                success = self.circuit_breaker.reset(admin_override=admin_override)
+                status = self.circuit_breaker.get_status()
+                return {
+                    "success": success,
+                    "data": {
+                        "reset": success,
+                        "message": "Circuit breaker reset" if success else "Reset failed - too many trips (admin override required)",
+                        "status": status,
+                    },
+                    "timestamp": datetime.now().isoformat(),
+                }
+            except Exception as e:
+                logger.error(f"Circuit breaker reset error: {e}")
                 return {"success": False, "error": str(e), "timestamp": datetime.now().isoformat()}
 
     async def start(self) -> None:

--- a/tests/test_circuit_breaker_wiring.py
+++ b/tests/test_circuit_breaker_wiring.py
@@ -1,0 +1,333 @@
+"""Tests for circuit breaker wiring into order execution path."""
+
+import pytest
+from unittest.mock import MagicMock, AsyncMock, patch
+from datetime import datetime
+
+from ibkr_mcp.config import ServerConfig, IBKRConfig, MCPConfig, RiskConfig
+from ibkr_mcp.server import IBKRMCPServer
+from ibkr_mcp.utils.circuit_breaker import TradingCircuitBreaker
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def risk_config():
+    """Create risk config with tight limits for testing."""
+    return RiskConfig(
+        max_loss_per_minute=100.0,
+        max_trades_per_minute=5,
+        max_daily_loss=500.0,
+        max_position_size=1000.0,
+    )
+
+
+@pytest.fixture
+def server_config(risk_config):
+    """Create test server config with risk config."""
+    return ServerConfig(
+        ibkr=IBKRConfig(
+            host="127.0.0.1",
+            port=7497,
+            client_id=99,
+            timeout=10,
+            readonly=False,
+        ),
+        mcp=MCPConfig(transport="stdio"),
+        risk=risk_config,
+    )
+
+
+@pytest.fixture
+def server(server_config):
+    """Create server instance with mocked client and FastMCP."""
+    with patch("ibkr_mcp.server.IBKRClient") as mock_client_cls, \
+         patch("ibkr_mcp.server.FastMCP") as mock_fastmcp_cls:
+        mock_client = MagicMock()
+        mock_client.register_event_handler = MagicMock()
+        mock_client_cls.return_value = mock_client
+
+        mock_mcp = MagicMock()
+        mock_mcp.tool = MagicMock(return_value=lambda f: f)
+        mock_fastmcp_cls.return_value = mock_mcp
+
+        srv = IBKRMCPServer(server_config)
+        srv.client = mock_client
+        return srv
+
+
+# =============================================================================
+# Initialization Tests
+# =============================================================================
+
+
+class TestCircuitBreakerInitialization:
+    """Test that circuit breaker is properly instantiated from config."""
+
+    def test_circuit_breaker_created(self, server):
+        """Circuit breaker should be instantiated on server init."""
+        assert hasattr(server, "circuit_breaker")
+        assert isinstance(server.circuit_breaker, TradingCircuitBreaker)
+
+    def test_circuit_breaker_limits_from_config(self, server, risk_config):
+        """Circuit breaker limits should match risk config values."""
+        cb = server.circuit_breaker
+        assert cb.max_loss_per_minute == risk_config.max_loss_per_minute
+        assert cb.max_trades_per_minute == risk_config.max_trades_per_minute
+        assert cb.max_daily_loss == risk_config.max_daily_loss
+        assert cb.max_position_size == risk_config.max_position_size
+
+    def test_event_handler_registered(self, server):
+        """Order status event handler should be registered on client."""
+        server.client.register_event_handler.assert_called_once_with(
+            "order_status", server._on_order_status
+        )
+
+
+# =============================================================================
+# Trade Value Estimation Tests
+# =============================================================================
+
+
+class TestEstimateTradeValue:
+    """Test trade value estimation for circuit breaker checks."""
+
+    def test_with_limit_price(self, server):
+        value = server._estimate_trade_value(100, limit_price=50.0)
+        assert value == 5000.0
+
+    def test_with_stop_price(self, server):
+        value = server._estimate_trade_value(100, stop_price=45.0)
+        assert value == 4500.0
+
+    def test_with_entry_price(self, server):
+        value = server._estimate_trade_value(100, entry_price=55.0)
+        assert value == 5500.0
+
+    def test_limit_price_takes_precedence(self, server):
+        value = server._estimate_trade_value(100, limit_price=50.0, stop_price=45.0)
+        assert value == 5000.0
+
+    def test_market_order_returns_zero(self, server):
+        value = server._estimate_trade_value(100)
+        assert value == 0.0
+
+    def test_negative_quantity_uses_abs(self, server):
+        value = server._estimate_trade_value(-100, limit_price=50.0)
+        assert value == 5000.0
+
+
+# =============================================================================
+# Circuit Breaker Check Tests
+# =============================================================================
+
+
+class TestCheckCircuitBreaker:
+    """Test circuit breaker pre-trade validation."""
+
+    def test_allows_normal_trade(self, server):
+        result = server._check_circuit_breaker(500.0)
+        assert result is None
+
+    def test_blocks_oversized_trade(self, server):
+        """Trade exceeding max_position_size should be blocked."""
+        result = server._check_circuit_breaker(2000.0)
+        assert result is not None
+        assert result["success"] is False
+        assert "Circuit breaker" in result["error"]
+        assert "Position size" in result["error"]
+
+    def test_blocks_when_tripped(self, server):
+        """All trades should be blocked when breaker is tripped."""
+        server.circuit_breaker.trip("test trip")
+        result = server._check_circuit_breaker(100.0)
+        assert result is not None
+        assert result["success"] is False
+        assert "tripped" in result["error"]
+
+    def test_blocks_excessive_trade_rate(self, server):
+        """Should block after exceeding max_trades_per_minute."""
+        # max_trades_per_minute is 5 for test config
+        for _ in range(5):
+            result = server._check_circuit_breaker(100.0)
+            assert result is None
+
+        # 6th trade should be blocked
+        result = server._check_circuit_breaker(100.0)
+        assert result is not None
+        assert result["success"] is False
+        assert "Too many trades" in result["error"]
+
+
+# =============================================================================
+# Fill Callback Tests
+# =============================================================================
+
+
+class TestFillCallback:
+    """Test P&L recording from order fill events."""
+
+    def test_records_commission_on_fill(self, server):
+        """Commission should be recorded as negative P&L on fill."""
+        event_data = {
+            "status": "Filled",
+            "filled": 100,
+            "avg_fill_price": 50.0,
+            "action": "BUY",
+            "commission": 1.50,
+        }
+        server._on_order_status(event_data)
+        assert server.circuit_breaker.daily_pnl == -1.50
+
+    def test_ignores_non_filled_status(self, server):
+        """Non-filled events should not record P&L."""
+        event_data = {
+            "status": "Submitted",
+            "filled": 0,
+            "avg_fill_price": 0,
+            "action": "BUY",
+            "commission": None,
+        }
+        server._on_order_status(event_data)
+        assert server.circuit_breaker.daily_pnl == 0.0
+
+    def test_handles_missing_commission(self, server):
+        """Fill without commission data should not crash."""
+        event_data = {
+            "status": "Filled",
+            "filled": 100,
+            "avg_fill_price": 50.0,
+            "action": "BUY",
+            "commission": None,
+        }
+        server._on_order_status(event_data)
+        assert server.circuit_breaker.daily_pnl == 0.0
+
+    def test_handles_malformed_event(self, server):
+        """Malformed event data should not crash."""
+        server._on_order_status({})
+        server._on_order_status({"status": "Filled"})
+        assert server.circuit_breaker.daily_pnl == 0.0
+
+
+# =============================================================================
+# Circuit Breaker Status/Reset Tests
+# =============================================================================
+
+
+class TestCircuitBreakerStatus:
+    """Test the circuit breaker status reporting."""
+
+    def test_status_returns_all_fields(self, server):
+        status = server.circuit_breaker.get_status()
+        assert "is_tripped" in status
+        assert "trip_reason" in status
+        assert "trip_count" in status
+        assert "daily_pnl" in status
+        assert "trades_last_minute" in status
+        assert "loss_last_minute" in status
+        assert "limits" in status
+        assert "utilization" in status
+
+    def test_status_reflects_trip(self, server):
+        server.circuit_breaker.trip("test reason")
+        status = server.circuit_breaker.get_status()
+        assert status["is_tripped"] is True
+        assert status["trip_reason"] == "test reason"
+        assert status["trip_count"] == 1
+
+
+class TestCircuitBreakerReset:
+    """Test the circuit breaker reset mechanism."""
+
+    def test_reset_clears_trip(self, server):
+        server.circuit_breaker.trip("test")
+        success = server.circuit_breaker.reset()
+        assert success is True
+        assert server.circuit_breaker.is_tripped is False
+
+    def test_reset_blocked_after_three_trips(self, server):
+        for _ in range(3):
+            server.circuit_breaker.trip("repeated issue")
+            server.circuit_breaker.is_tripped = False
+
+        server.circuit_breaker.trip("fourth trip")
+        success = server.circuit_breaker.reset()
+        assert success is False
+        assert server.circuit_breaker.is_tripped is True
+
+    def test_admin_override_reset(self, server):
+        for _ in range(3):
+            server.circuit_breaker.trip("repeated issue")
+            server.circuit_breaker.is_tripped = False
+
+        server.circuit_breaker.trip("fourth trip")
+        success = server.circuit_breaker.reset(admin_override=True)
+        assert success is True
+        assert server.circuit_breaker.is_tripped is False
+
+
+# =============================================================================
+# Integration: Order Tools Block When Tripped
+# =============================================================================
+
+
+class TestOrderToolsCircuitBreakerIntegration:
+    """Verify that order tools respect circuit breaker state."""
+
+    def test_tripped_breaker_blocks_all_orders(self, server):
+        """When tripped, _check_circuit_breaker should block regardless of value."""
+        server.circuit_breaker.trip("daily loss exceeded")
+
+        # Even a $0 trade value should be blocked when tripped
+        result = server._check_circuit_breaker(0.0)
+        assert result is not None
+        assert result["success"] is False
+
+    def test_position_size_limit_enforced(self, server):
+        """Trades exceeding position size limit should be blocked."""
+        # max_position_size is 1000 in test config
+        result = server._check_circuit_breaker(1001.0)
+        assert result is not None
+        assert result["success"] is False
+        assert "Position size" in result["error"]
+
+    def test_under_limit_trade_allowed(self, server):
+        result = server._check_circuit_breaker(999.0)
+        assert result is None
+
+    def test_zero_value_trade_allowed(self, server):
+        """Market orders (value=0) should pass position size check."""
+        result = server._check_circuit_breaker(0.0)
+        assert result is None
+
+
+# =============================================================================
+# Daily P&L Tracking Integration
+# =============================================================================
+
+
+class TestDailyPnlTracking:
+    """Test that P&L accumulates and triggers circuit breaker."""
+
+    def test_cumulative_commission_tracking(self, server):
+        """Multiple fills should accumulate commission costs."""
+        for i in range(3):
+            server._on_order_status({
+                "status": "Filled",
+                "filled": 100,
+                "avg_fill_price": 50.0,
+                "action": "BUY",
+                "commission": 1.50,
+            })
+        assert server.circuit_breaker.daily_pnl == pytest.approx(-4.50)
+
+    def test_large_loss_trips_breaker(self, server):
+        """Recording large loss via record_pnl should trip breaker."""
+        # max_daily_loss is 500 in test config
+        server.circuit_breaker.record_pnl(-600.0)
+        assert server.circuit_breaker.is_tripped is True
+        assert "Daily loss" in server.circuit_breaker.trip_reason


### PR DESCRIPTION
## Summary
- Instantiate `TradingCircuitBreaker` in `server.__init__` from `config.risk` parameters
- Add pre-trade circuit breaker checks to all 11 order-placement MCP tools (`place_order`, `place_bracket_order`, `place_trailing_stop`, `place_one_cancels_all`, `place_algo_order`, `place_twap_order`, `place_vwap_order`, `place_arrival_price_order`, `place_adaptive_order`, `execute_rebalancing`, `set_stop_loss_orders`)
- Wire `record_pnl()` into fill callbacks via the client's `order_status` event system to track commission costs
- Expose `circuit_breaker_status` and `circuit_breaker_reset` MCP tools for monitoring and control

## Implementation Details
- `_estimate_trade_value()` computes dollar value from available price info (limit, stop, or entry price); market/algo orders pass 0.0 to skip position size check while still enforcing rate limits and tripped-state blocks
- `_check_circuit_breaker()` returns a standardized error dict when blocked, or `None` when allowed
- `_on_order_status()` event handler records commission as negative P&L on fills; extensible for full position-based P&L tracking
- Circuit breaker tools follow the same response format as all other MCP tools

## Test plan
- [x] 28 unit tests covering all circuit breaker wiring (initialization, trade value estimation, pre-trade checks, fill callbacks, status/reset, integration scenarios)
- [x] All tests passing locally

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)